### PR TITLE
cortex-a7: Fix build

### DIFF
--- a/libc/arch-arm/cortex-a7/cortex-a7.mk
+++ b/libc/arch-arm/cortex-a7/cortex-a7.mk
@@ -2,8 +2,8 @@ libc_bionic_src_files_arm += \
     arch-arm/cortex-a7/bionic/memset.S \
 
 libc_bionic_src_files_arm += \
+    arch-arm/cortex-a15/bionic/memchr.S \
     arch-arm/cortex-a15/bionic/memcpy.S \
-    arch-arm/cortex-a15/bionic/stpcpy.S \
     arch-arm/cortex-a15/bionic/strcat.S \
     arch-arm/cortex-a15/bionic/__strcat_chk.S \
     arch-arm/cortex-a15/bionic/strcmp.S \


### PR DESCRIPTION
- stpcpy.S is already defined
- memchr.S was missing

Commit taken from ProjectX-Android/bionic commit: d937421274347e883e4092d1e7da970bb667eb8e
